### PR TITLE
Swapped URLs from jfrog to boost archive

### DIFF
--- a/project/boost/version.py
+++ b/project/boost/version.py
@@ -63,8 +63,8 @@ class Version:
     def archive_name(self):
         return f'{self.dir_name}{self.archive_ext}'
 
-    def _get_jfrog_url(self):
-        return f'https://boostorg.jfrog.io/artifactory/main/release/{self}/source/{self.archive_name}'
+    def _get_archive_url(self):
+        return f'https://archives.boost.io/release/{self}/source/{self.archive_name}'
 
     def _get_sourceforge_url(self):
         return f'https://sourceforge.net/projects/boost/files/boost/{self}/{self.archive_name}/download'
@@ -74,4 +74,4 @@ class Version:
             # For versions older than 1.63.0, SourceForge is the only option:
             return [self._get_sourceforge_url()]
         # Otherwise, jfrog.io is preferred (the official website links to it).
-        return [self._get_jfrog_url(), self._get_sourceforge_url()]
+        return [self._get_archive_url(), self._get_sourceforge_url()]


### PR DESCRIPTION
Fixes issue with the jFrog URL no longer working by substituting it with the archives.boost.io link currently used on the boost download page