### PR TITLE
Removed old python and macos build images

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -61,7 +61,7 @@ jobs:
   python-versions:
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
         include:
           - os: ubuntu-latest
           - boost-version: 1.78.0

--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -26,7 +26,7 @@ jobs:
   os:
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-11, macos-12]
+        os: [ubuntu-20.04, ubuntu-22.04, windows-2019, windows-2022, macos-13, macos-14]
         include:
           - boost-version: 1.78.0
     runs-on: '${{ matrix.os }}'

--- a/project/boost/version.py
+++ b/project/boost/version.py
@@ -63,8 +63,8 @@ class Version:
     def archive_name(self):
         return f'{self.dir_name}{self.archive_ext}'
 
-    def _get_jfrog_url(self):
-        return f'https://boostorg.jfrog.io/artifactory/main/release/{self}/source/{self.archive_name}'
+    def _get_archive_url(self):
+        return f'https://archives.boost.io/release/{self}/source/{self.archive_name}'
 
     def _get_sourceforge_url(self):
         return f'https://sourceforge.net/projects/boost/files/boost/{self}/{self.archive_name}/download'
@@ -74,4 +74,4 @@ class Version:
             # For versions older than 1.63.0, SourceForge is the only option:
             return [self._get_sourceforge_url()]
         # Otherwise, jfrog.io is preferred (the official website links to it).
-        return [self._get_jfrog_url(), self._get_sourceforge_url()]
+        return [self._get_archive_url(), self._get_sourceforge_url()]


### PR DESCRIPTION
Seems python 3.7 is no longer supported on ubuntu-latest and the old macos image are no longer available so swapped them for newer ones.

I am not 100% sure how pipelines here work so could be other pipelines that need updating as well, but "basic" now build for me (and download ones already seemed to work before this).

This also includes the jFrog fix as I was lazy, if you want I can split them up if not you can merge them both here or rebase this after you have merge the other one... Let me know how you want this...